### PR TITLE
bug: fix #46 ('no tags' in media page is not being translated)

### DIFF
--- a/frontend/static/js/media-viewer-base.js
+++ b/frontend/static/js/media-viewer-base.js
@@ -103,7 +103,7 @@ class MediaViewerBase {
             `;
         });
 
-        container.innerHTML = html || window.i18n.t('bulk_modal.messages.no_tags');
+        container.innerHTML = html || '<p class="text-xs text-secondary mb-3">' + window.i18n.t('bulk_modal.messages.no_tags') + '</p>';
     }
 
     async renderAIMetadata(media, options = {}) {


### PR DESCRIPTION
changed hard-coded "no tags" placeholder to a dynamically changing string based on currently selected language


### ru:

general media page:
<img width="1500" height="900" alt="no_tags_ru" src="https://github.com/user-attachments/assets/54b381a5-8c4f-4ba3-9641-b02b03418fb1" />
shared media page:
<img width="1500" height="900"  alt="no_tags_shared_ru" src="https://github.com/user-attachments/assets/ec1320e2-7f29-4316-b9ed-4180f6bd6ff9" />

### en:

general media page:
<img width="1500" height="900"  alt="image" src="https://github.com/user-attachments/assets/7eb2d008-428f-4e88-994a-0bca4e212f5d" />
shared media page:
<img width="1500" height="900" alt="no_tags_shared_en" src="https://github.com/user-attachments/assets/39c837e3-3591-46ef-a9f2-e2becbaadd74" />

### sv:
general media page:
<img width="1500" height="900"  alt="no_tags_sv" src="https://github.com/user-attachments/assets/d6340721-0bb6-4502-b98d-d840a5517406" />
shared media page:
<img width="1500" height="900" alt="no_tags_shared_sv" src="https://github.com/user-attachments/assets/57d243e0-75f1-4176-a484-f48e74608402" />


