### PR TITLE
Enhanced sorting

### DIFF
--- a/backend/app/routes/albums.py
+++ b/backend/app/routes/albums.py
@@ -434,22 +434,7 @@ async def get_album_contents(
         blombooru_album_hierarchy.c.parent_album_id == album_id
     )
     
-    # Sort Albums
-    album_sort_mapping = {
-        'name': Album.name,
-        'filename': Album.name,
-        'last_modified': Album.last_modified,
-        'uploaded_at': Album.created_at
-    }
-    
-    album_sort_column = album_sort_mapping.get(sort, Album.created_at)
-    
-    # Apply Sort using column methods
-    if sort_order == "asc":
-        child_albums_query = child_albums_query.order_by(album_sort_column.asc())
-    else:
-        child_albums_query = child_albums_query.order_by(album_sort_column.desc())
-
+    child_albums_query = apply_album_sort(child_albums_query, sort, sort_order, seed)
     child_albums = child_albums_query.all()
     
     # Build Album Response List (with rating logic)

--- a/backend/app/routes/albums.py
+++ b/backend/app/routes/albums.py
@@ -20,7 +20,7 @@ from ..utils.album_utils import (get_album_popular_tags, get_album_rating,
                                  update_album_last_modified)
 from ..utils.cache import cache_response, invalidate_album_cache
 from ..utils.logger import logger
-from ..utils.media_sort import apply_media_sort
+from ..utils.media_sort import apply_album_sort, apply_media_sort
 from ..utils.search_parser import apply_search_criteria, parse_search_query
 
 router = APIRouter(prefix="/api/albums", tags=["albums"])
@@ -40,6 +40,7 @@ async def get_albums(
     limit: Optional[int] = Query(default=None),
     sort: Optional[str] = Query(default="created_at"),
     order: Optional[str] = Query(default="desc"),
+    seed: Optional[str] = Query(default=None),
     rating: Optional[str] = None,
     root_only: bool = Query(default=False),
     db: Session = Depends(get_db)
@@ -54,17 +55,10 @@ async def get_albums(
         # Only show albums that are not children of any other album
         query = query.filter(~Album.id.in_(db.query(blombooru_album_hierarchy.c.child_album_id)))
     
-    # Apply sorting
-    sort_column = Album.created_at
-    if sort == "name":
-        sort_column = Album.name
-    elif sort == "last_modified":
-        sort_column = Album.last_modified
-    
-    if order == "desc":
-        query = query.order_by(desc(sort_column))
-    else:
-        query = query.order_by(asc(sort_column))
+    sort_order = order.lower() if order else "desc"
+    if sort_order not in ("asc", "desc"):
+        sort_order = "desc"
+    query = apply_album_sort(query, sort or "created_at", sort_order, seed)
     
     # Get all albums
     all_albums = query.all()
@@ -362,7 +356,7 @@ async def get_album_contents(
     q: Optional[str] = Query(default=None),
     sort: str = Query(default="uploaded_at"),
     order: str = Query(default="desc"),
-    seed: Optional[str] = None,
+    seed: Optional[str] = Query(default=None),
     db: Session = Depends(get_db)
 ):
     """Get album contents (media + sub-albums, paginated)"""
@@ -412,26 +406,18 @@ async def get_album_contents(
             media_query = media_query.filter(Media.rating.in_(allowed_ratings.get(rating, [])))
     
     # Sort Media
-    if sort in ('random', 'tag_count'):
-        media_query = apply_media_sort(media_query, sort, sort_order, db, seed)
-    else:
-        media_sort_mapping = {
+    media_query = apply_media_sort(
+        media_query,
+        sort,
+        sort_order,
+        db,
+        seed,
+        column_overrides={
             'uploaded_at': Media.id,
-            'filename': Media.filename,
+            'last_modified': Media.id,
             'name': Media.filename,
-            'file_size': Media.file_size,
-            'file_type': Media.file_type,
-            'last_modified': Media.id
-        }
-
-        # Default to Media.id if key not found
-        media_sort_column = media_sort_mapping.get(sort, Media.id)
-        
-        # Apply Sort using column methods
-        if sort_order == "asc":
-            media_query = media_query.order_by(media_sort_column.asc())
-        else:
-            media_query = media_query.order_by(media_sort_column.desc())
+        },
+    )
 
     # Get total count BEFORE pagination
     total_media = media_query.count()

--- a/backend/app/routes/albums.py
+++ b/backend/app/routes/albums.py
@@ -20,6 +20,7 @@ from ..utils.album_utils import (get_album_popular_tags, get_album_rating,
                                  update_album_last_modified)
 from ..utils.cache import cache_response, invalidate_album_cache
 from ..utils.logger import logger
+from ..utils.media_sort import apply_media_sort
 from ..utils.search_parser import apply_search_criteria, parse_search_query
 
 router = APIRouter(prefix="/api/albums", tags=["albums"])
@@ -361,6 +362,7 @@ async def get_album_contents(
     q: Optional[str] = Query(default=None),
     sort: str = Query(default="uploaded_at"),
     order: str = Query(default="desc"),
+    seed: Optional[str] = None,
     db: Session = Depends(get_db)
 ):
     """Get album contents (media + sub-albums, paginated)"""
@@ -410,23 +412,26 @@ async def get_album_contents(
             media_query = media_query.filter(Media.rating.in_(allowed_ratings.get(rating, [])))
     
     # Sort Media
-    media_sort_mapping = {
-        'uploaded_at': Media.id,
-        'filename': Media.filename,
-        'name': Media.filename,
-        'file_size': Media.file_size,
-        'file_type': Media.file_type,
-        'last_modified': Media.id
-    }
-    
-    # Default to Media.id if key not found
-    media_sort_column = media_sort_mapping.get(sort, Media.id)
-    
-    # Apply Sort using column methods
-    if sort_order == "asc":
-        media_query = media_query.order_by(media_sort_column.asc())
+    if sort in ('random', 'tag_count'):
+        media_query = apply_media_sort(media_query, sort, sort_order, db, seed)
     else:
-        media_query = media_query.order_by(media_sort_column.desc())
+        media_sort_mapping = {
+            'uploaded_at': Media.id,
+            'filename': Media.filename,
+            'name': Media.filename,
+            'file_size': Media.file_size,
+            'file_type': Media.file_type,
+            'last_modified': Media.id
+        }
+
+        # Default to Media.id if key not found
+        media_sort_column = media_sort_mapping.get(sort, Media.id)
+        
+        # Apply Sort using column methods
+        if sort_order == "asc":
+            media_query = media_query.order_by(media_sort_column.asc())
+        else:
+            media_query = media_query.order_by(media_sort_column.desc())
 
     # Get total count BEFORE pagination
     total_media = media_query.count()

--- a/backend/app/routes/media.py
+++ b/backend/app/routes/media.py
@@ -472,7 +472,7 @@ async def get_media_list(
     rating: Optional[str] = None,
     sort: Optional[str] = None,
     order: Optional[str] = None,
-    seed: Optional[str] = None,
+    seed: Optional[str] = Query(default=None),
     db: Session = Depends(get_db)
 ):
     """Get paginated media list"""

--- a/backend/app/routes/media.py
+++ b/backend/app/routes/media.py
@@ -32,6 +32,7 @@ from ..utils.media_helpers import (create_stripped_media_cache,
                                    get_unique_filename, sanitize_filename,
                                    serve_media_file)
 from ..utils.media_processor import calculate_file_hash, process_media_file
+from ..utils.media_sort import apply_media_sort
 from ..utils.thumbnail_generator import generate_thumbnail
 
 router = APIRouter(prefix="/api/media", tags=["media"])
@@ -471,6 +472,7 @@ async def get_media_list(
     rating: Optional[str] = None,
     sort: Optional[str] = None,
     order: Optional[str] = None,
+    seed: Optional[str] = None,
     db: Session = Depends(get_db)
 ):
     """Get paginated media list"""
@@ -490,19 +492,7 @@ async def get_media_list(
         # Sorting
         sort_by = sort if sort else settings.get_default_sort()
         sort_order = order if order else settings.get_default_order()
-        
-        sort_column = Media.uploaded_at
-        if sort_by == 'filename':
-            sort_column = Media.filename
-        elif sort_by == 'file_size':
-            sort_column = Media.file_size
-        elif sort_by == 'file_type':
-            sort_column = Media.file_type
-            
-        if sort_order == 'asc':
-            query = query.order_by(sort_column.asc())
-        else:
-            query = query.order_by(sort_column.desc())
+        query = apply_media_sort(query, sort_by, sort_order, db, seed)
         
         # Pagination
         offset = (page - 1) * limit

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -10,6 +10,7 @@ from ..database import get_db
 from ..models import Media
 from ..schemas import MediaResponse
 from ..utils.cache import cache_response
+from ..utils.media_sort import apply_media_sort
 from ..utils.search_parser import apply_search_criteria, parse_search_query
 
 router = APIRouter(prefix="/api/search", tags=["search"])
@@ -23,6 +24,9 @@ async def search_media(
     rating: Optional[str] = None,
     page: int = 1,
     limit: int = Query(None),
+    sort: Optional[str] = None,
+    order: Optional[str] = None,
+    seed: Optional[str] = None,
     db: Session = Depends(get_db)
 ):
     """Search media with tag-based query"""
@@ -40,6 +44,13 @@ async def search_media(
 
     # Apply all criteria
     query = apply_search_criteria(query, parsed, db)
+
+    # Apply UI sort/order unless the search query specifies its own ordering
+    if 'order' not in parsed['meta'] and 'sort' not in parsed['meta']:
+        sort_by = sort if sort else settings.get_default_sort()
+        sort_order = order if order else settings.get_default_order()
+        query = query.order_by(None)
+        query = apply_media_sort(query, sort_by, sort_order, db, seed)
     
     # Pagination
     offset = (page - 1) * limit

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -26,7 +26,7 @@ async def search_media(
     limit: int = Query(None),
     sort: Optional[str] = None,
     order: Optional[str] = None,
-    seed: Optional[str] = None,
+    seed: Optional[str] = Query(default=None),
     db: Session = Depends(get_db)
 ):
     """Search media with tag-based query"""

--- a/backend/app/utils/media_sort.py
+++ b/backend/app/utils/media_sort.py
@@ -1,9 +1,20 @@
-from typing import Optional
+import re
+from typing import Any, Optional
 
 from sqlalchemy import String, cast, func, literal
 from sqlalchemy.orm import Query, Session
 
-from ..models import Media, blombooru_media_tags
+from ..models import Album, Media, blombooru_media_tags
+
+MAX_RANDOM_SEED_LENGTH = 32
+_RANDOM_SEED_PATTERN = re.compile(r"^\d{1,32}$")
+
+
+def normalize_random_seed(seed: Optional[str]) -> Optional[str]:
+    """Accept only Date.now()-style numeric seeds (digits, max 32 chars)."""
+    if not seed or not _RANDOM_SEED_PATTERN.match(seed):
+        return None
+    return seed
 
 
 def apply_media_sort(
@@ -12,13 +23,16 @@ def apply_media_sort(
     sort_order: str = "desc",
     db: Optional[Session] = None,
     seed: Optional[str] = None,
+    column_overrides: Optional[dict[str, Any]] = None,
 ) -> Query:
     """Apply sort ordering to a Media query at the database level."""
     ascending = sort_order == "asc"
+    overrides = column_overrides or {}
 
     if sort_by == "random":
-        if seed:
-            hash_input = func.concat(cast(Media.id, String), literal(seed))
+        normalized_seed = normalize_random_seed(seed)
+        if normalized_seed:
+            hash_input = func.concat(cast(Media.id, String), literal(normalized_seed))
             return query.order_by(func.md5(hash_input))
         return query.order_by(func.random())
 
@@ -34,14 +48,46 @@ def apply_media_sort(
             return query.order_by(tag_count_subq.asc(), Media.id.asc())
         return query.order_by(tag_count_subq.desc(), Media.id.desc())
 
-    sort_column = Media.uploaded_at
-    if sort_by == "filename":
+    if sort_by in overrides:
+        sort_column = overrides[sort_by]
+    elif sort_by == "filename":
         sort_column = Media.filename
     elif sort_by == "file_size":
         sort_column = Media.file_size
     elif sort_by == "file_type":
         sort_column = Media.file_type
+    else:
+        sort_column = Media.uploaded_at
 
     if ascending:
         return query.order_by(sort_column.asc(), Media.id.asc())
     return query.order_by(sort_column.desc(), Media.id.desc())
+
+
+def apply_album_sort(
+    query: Query,
+    sort_by: str,
+    sort_order: str = "desc",
+    seed: Optional[str] = None,
+) -> Query:
+    """Apply sort ordering to an Album query at the database level."""
+    ascending = sort_order == "asc"
+
+    if sort_by == "random":
+        normalized_seed = normalize_random_seed(seed)
+        if normalized_seed:
+            hash_input = func.concat(cast(Album.id, String), literal(normalized_seed))
+            return query.order_by(func.md5(hash_input))
+        return query.order_by(func.random())
+
+    if sort_by == "name" or sort_by == "filename":
+        sort_column = Album.name
+    elif sort_by == "last_modified":
+        sort_column = Album.last_modified
+    else:
+        # uploaded_at, created_at, and unknown values default to created_at
+        sort_column = Album.created_at
+
+    if ascending:
+        return query.order_by(sort_column.asc(), Album.id.asc())
+    return query.order_by(sort_column.desc(), Album.id.desc())

--- a/backend/app/utils/media_sort.py
+++ b/backend/app/utils/media_sort.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+from sqlalchemy import String, cast, func, literal
+from sqlalchemy.orm import Query, Session
+
+from ..models import Media, blombooru_media_tags
+
+
+def apply_media_sort(
+    query: Query,
+    sort_by: str,
+    sort_order: str = "desc",
+    db: Optional[Session] = None,
+    seed: Optional[str] = None,
+) -> Query:
+    """Apply sort ordering to a Media query at the database level."""
+    ascending = sort_order == "asc"
+
+    if sort_by == "random":
+        if seed:
+            hash_input = func.concat(cast(Media.id, String), literal(seed))
+            return query.order_by(func.md5(hash_input))
+        return query.order_by(func.random())
+
+    if sort_by == "tag_count":
+        if db is None:
+            raise ValueError("db session is required for tag_count sorting")
+        tag_count_subq = (
+            db.query(func.count(blombooru_media_tags.c.tag_id))
+            .filter(blombooru_media_tags.c.media_id == Media.id)
+            .scalar_subquery()
+        )
+        if ascending:
+            return query.order_by(tag_count_subq.asc(), Media.id.asc())
+        return query.order_by(tag_count_subq.desc(), Media.id.desc())
+
+    sort_column = Media.uploaded_at
+    if sort_by == "filename":
+        sort_column = Media.filename
+    elif sort_by == "file_size":
+        sort_column = Media.file_size
+    elif sort_by == "file_type":
+        sort_column = Media.file_type
+
+    if ascending:
+        return query.order_by(sort_column.asc(), Media.id.asc())
+    return query.order_by(sort_column.desc(), Media.id.desc())

--- a/backend/app/utils/media_sort.py
+++ b/backend/app/utils/media_sort.py
@@ -7,7 +7,8 @@ from sqlalchemy.orm import Query, Session
 from ..models import Album, Media, blombooru_media_tags
 
 MAX_RANDOM_SEED_LENGTH = 32
-_RANDOM_SEED_PATTERN = re.compile(r"^\d{1,32}$")
+DEFAULT_RANDOM_SEED = "0"
+_RANDOM_SEED_PATTERN = re.compile(rf"^\d{{1,{MAX_RANDOM_SEED_LENGTH}}}$")
 
 
 def normalize_random_seed(seed: Optional[str]) -> Optional[str]:
@@ -15,6 +16,10 @@ def normalize_random_seed(seed: Optional[str]) -> Optional[str]:
     if not seed or not _RANDOM_SEED_PATTERN.match(seed):
         return None
     return seed
+
+
+def _effective_random_seed(seed: Optional[str]) -> str:
+    return normalize_random_seed(seed) or DEFAULT_RANDOM_SEED
 
 
 def apply_media_sort(
@@ -30,11 +35,9 @@ def apply_media_sort(
     overrides = column_overrides or {}
 
     if sort_by == "random":
-        normalized_seed = normalize_random_seed(seed)
-        if normalized_seed:
-            hash_input = func.concat(cast(Media.id, String), literal(normalized_seed))
-            return query.order_by(func.md5(hash_input))
-        return query.order_by(func.random())
+        effective_seed = _effective_random_seed(seed)
+        hash_input = func.concat(cast(Media.id, String), literal(effective_seed))
+        return query.order_by(func.md5(hash_input))
 
     if sort_by == "tag_count":
         if db is None:
@@ -74,11 +77,9 @@ def apply_album_sort(
     ascending = sort_order == "asc"
 
     if sort_by == "random":
-        normalized_seed = normalize_random_seed(seed)
-        if normalized_seed:
-            hash_input = func.concat(cast(Album.id, String), literal(normalized_seed))
-            return query.order_by(func.md5(hash_input))
-        return query.order_by(func.random())
+        effective_seed = _effective_random_seed(seed)
+        hash_input = func.concat(cast(Album.id, String), literal(effective_seed))
+        return query.order_by(func.md5(hash_input))
 
     if sort_by == "name" or sort_by == "filename":
         sort_column = Album.name

--- a/frontend/static/css/main.css
+++ b/frontend/static/css/main.css
@@ -696,6 +696,14 @@ span.checked:hover {
     background-color: var(--surface-hover);
 }
 
+.sort-order-toggle .sort-order-chevron {
+    transition: transform 0.2s ease;
+}
+
+.sort-order-toggle.asc .sort-order-chevron {
+    transform: rotate(180deg);
+}
+
 /* Share icon overlay */
 .share-icon {
     position: absolute;

--- a/frontend/static/js/admin/system.js
+++ b/frontend/static/js/admin/system.js
@@ -18,7 +18,7 @@ class AdminSystem {
         if (defaultSortElement) {
             this.defaultSortSelect = new CustomSelect(defaultSortElement);
             defaultSortElement.addEventListener('change', () => {
-                this.updateDefaultOrderVisibility();
+                this.updateDefaultOrderState();
             });
         }
 
@@ -27,7 +27,7 @@ class AdminSystem {
             this.defaultOrderSelect = new CustomSelect(defaultOrderElement);
         }
 
-        this.updateDefaultOrderVisibility();
+        this.updateDefaultOrderState();
 
         const popularTagsModeElement = document.getElementById('popular-tags-mode');
         if (popularTagsModeElement) {
@@ -305,12 +305,11 @@ class AdminSystem {
         div.style.filter = `blur(${blur}px) brightness(${brightness}%) saturate(${saturation}%) contrast(${contrast}%)`;
     }
 
-    updateDefaultOrderVisibility() {
-        const orderEl = document.getElementById('default-order');
-        if (!orderEl || !this.defaultSortSelect) return;
+    updateDefaultOrderState() {
+        if (!this.defaultOrderSelect) return;
 
-        const isRandom = this.defaultSortSelect.getValue() === 'random';
-        orderEl.classList.toggle('hidden', isRandom);
+        const isRandom = this.defaultSortSelect?.getValue() === 'random';
+        this.defaultOrderSelect.setDisabled(isRandom);
     }
 
     cleanupCustomButtons() {
@@ -590,7 +589,7 @@ class AdminSystem {
 
             if (settings.default_sort && this.defaultSortSelect) {
                 this.defaultSortSelect.setValue(settings.default_sort);
-                this.updateDefaultOrderVisibility();
+                this.updateDefaultOrderState();
             }
 
             if (settings.default_order && this.defaultOrderSelect) {

--- a/frontend/static/js/admin/system.js
+++ b/frontend/static/js/admin/system.js
@@ -17,12 +17,17 @@ class AdminSystem {
         const defaultSortElement = document.getElementById('default-sort');
         if (defaultSortElement) {
             this.defaultSortSelect = new CustomSelect(defaultSortElement);
+            defaultSortElement.addEventListener('change', () => {
+                this.updateDefaultOrderVisibility();
+            });
         }
 
         const defaultOrderElement = document.getElementById('default-order');
         if (defaultOrderElement) {
             this.defaultOrderSelect = new CustomSelect(defaultOrderElement);
         }
+
+        this.updateDefaultOrderVisibility();
 
         const popularTagsModeElement = document.getElementById('popular-tags-mode');
         if (popularTagsModeElement) {
@@ -298,6 +303,14 @@ class AdminSystem {
         div.style.transform = `scale(${z})`;
         div.style.opacity = (opacity / 100).toFixed(2);
         div.style.filter = `blur(${blur}px) brightness(${brightness}%) saturate(${saturation}%) contrast(${contrast}%)`;
+    }
+
+    updateDefaultOrderVisibility() {
+        const orderEl = document.getElementById('default-order');
+        if (!orderEl || !this.defaultSortSelect) return;
+
+        const isRandom = this.defaultSortSelect.getValue() === 'random';
+        orderEl.classList.toggle('hidden', isRandom);
     }
 
     cleanupCustomButtons() {
@@ -577,6 +590,7 @@ class AdminSystem {
 
             if (settings.default_sort && this.defaultSortSelect) {
                 this.defaultSortSelect.setValue(settings.default_sort);
+                this.updateDefaultOrderVisibility();
             }
 
             if (settings.default_order && this.defaultOrderSelect) {

--- a/frontend/static/js/components/base-gallery.js
+++ b/frontend/static/js/components/base-gallery.js
@@ -53,8 +53,11 @@ class BaseGallery {
         }
 
         const urlParams = new URLSearchParams(window.location.search);
+        const sortControls = document.querySelector('.js-sort-controls');
+        const defaultOrderFromDom = sortControls?.dataset.defaultOrder || this.options.defaultOrder;
+
         this.currentSort = urlParams.get('sort') || this.elements.sortBy?.dataset.value || this.options.defaultSort;
-        this.currentOrder = urlParams.get('order') || this.options.defaultOrder;
+        this.currentOrder = urlParams.get('order') || defaultOrderFromDom;
         this.currentRandomSeed = urlParams.get('seed') || null;
     }
 
@@ -201,6 +204,8 @@ class BaseGallery {
         }
 
         this.sortBySelects = [];
+        this.sortOrderToggles = document.querySelectorAll('.js-sort-order-toggle');
+        this.sortRandomRegenBtns = document.querySelectorAll('.js-sort-random-regen');
 
         const sortByElements = document.querySelectorAll('.js-sort-by-select');
         const params = new URLSearchParams(window.location.search);
@@ -217,13 +222,7 @@ class BaseGallery {
                 this.sortBySelects.forEach(s => {
                     if (s !== select) s.setValue(newValue, false);
                 });
-                this.handleSortSelection(newValue);
-            });
-
-            select.dropdown.querySelectorAll('.custom-select-option').forEach(option => {
-                if (!option.dataset.baseLabel) {
-                    option.dataset.baseLabel = option.textContent.trim();
-                }
+                this.handleSortChange(newValue);
             });
 
             this.sortBySelects.push(select);
@@ -231,12 +230,21 @@ class BaseGallery {
 
         this.sortBySelect = this.sortBySelects[0];
 
+        this.sortOrderToggles.forEach(btn => {
+            btn.addEventListener('click', () => this.toggleSortOrder());
+        });
+
+        this.sortRandomRegenBtns.forEach(btn => {
+            btn.addEventListener('click', () => this.regenerateRandomSeed());
+        });
+
         if (this.currentSort === 'random' && !this.currentRandomSeed) {
             this.currentRandomSeed = String(Date.now());
             this.syncSortUrlParams();
         }
 
-        this.updateSortDisplay();
+        this.updateSortControlsVisibility();
+        this.updateSortOrderToggleState();
     }
 
     getSortValue() {
@@ -250,72 +258,58 @@ class BaseGallery {
         return this.currentOrder;
     }
 
-    handleSortSelection(newSort) {
+    handleSortChange(newSort) {
         const previousSort = this.currentSort;
+        this.currentSort = newSort;
 
-        if (newSort === previousSort) {
-            if (newSort === 'random') {
+        if (newSort === 'random') {
+            if (previousSort !== 'random' || !this.currentRandomSeed) {
                 this.currentRandomSeed = String(Date.now());
-            } else {
-                this.currentOrder = this.currentOrder === 'asc' ? 'desc' : 'asc';
             }
         } else {
-            this.currentSort = newSort;
-            if (newSort === 'random') {
-                this.currentRandomSeed = String(Date.now());
-            } else {
-                this.currentRandomSeed = null;
-                this.currentOrder = 'desc';
-            }
+            this.currentRandomSeed = null;
         }
 
-        this.updateSortDisplay();
+        this.updateSortControlsVisibility();
         this.syncSortUrlParams();
         this.onSortChange();
     }
 
-    getSortOrderIndicator(order) {
-        return order === 'asc' ? '↑' : '↓';
+    toggleSortOrder() {
+        if (this.currentSort === 'random') return;
+
+        this.currentOrder = this.currentOrder === 'asc' ? 'desc' : 'asc';
+        this.updateSortOrderToggleState();
+        this.syncSortUrlParams();
+        this.onSortChange();
     }
 
-    getSortBaseLabel(option) {
-        return option.dataset.baseLabel || option.textContent.trim();
+    regenerateRandomSeed() {
+        if (this.currentSort !== 'random') return;
+
+        this.currentRandomSeed = String(Date.now());
+        this.syncSortUrlParams();
+        this.onSortChange();
     }
 
-    formatSortLabel(baseLabel, sortValue, order, previewNext = false) {
-        if (sortValue === 'random') {
-            return previewNext ? `${baseLabel} ↻` : baseLabel;
-        }
-        const displayOrder = previewNext
-            ? (order === 'asc' ? 'desc' : 'asc')
-            : order;
-        return `${baseLabel} ${this.getSortOrderIndicator(displayOrder)}`;
+    updateSortControlsVisibility() {
+        const isRandom = this.currentSort === 'random';
+
+        this.sortOrderToggles.forEach(btn => {
+            btn.classList.toggle('hidden', isRandom);
+            btn.disabled = isRandom;
+        });
+
+        this.sortRandomRegenBtns.forEach(btn => {
+            btn.classList.toggle('hidden', !isRandom);
+        });
     }
 
-    updateSortDisplay() {
-        if (!this.sortBySelects) return;
-
-        this.sortBySelects.forEach(select => {
-            select.dropdown.querySelectorAll('.custom-select-option').forEach(option => {
-                const baseLabel = this.getSortBaseLabel(option);
-                const value = option.dataset.value;
-
-                if (value === this.currentSort) {
-                    option.textContent = this.formatSortLabel(
-                        baseLabel, value, this.currentOrder, true
-                    );
-                } else {
-                    option.textContent = baseLabel;
-                }
-            });
-
-            const currentOption = select.dropdown.querySelector(`[data-value="${this.currentSort}"]`);
-            if (currentOption) {
-                const baseLabel = this.getSortBaseLabel(currentOption);
-                select.valueDisplay.textContent = this.formatSortLabel(
-                    baseLabel, this.currentSort, this.currentOrder, false
-                );
-            }
+    updateSortOrderToggleState() {
+        this.sortOrderToggles.forEach(btn => {
+            btn.dataset.order = this.currentOrder;
+            btn.classList.remove('asc', 'desc');
+            btn.classList.add(this.currentOrder);
         });
     }
 
@@ -323,15 +317,16 @@ class BaseGallery {
         const params = {
             sort: this.currentSort,
             order: this.currentOrder,
-            seed: this.currentRandomSeed
+            seed: this.currentSort === 'random' ? this.currentRandomSeed : null
         };
         this.updateUrlParams(params);
     }
 
     appendSortParams(params) {
-        params.set('sort', this.getSortValue());
+        const sort = this.getSortValue();
+        params.set('sort', sort);
         params.set('order', this.getOrderValue());
-        if (this.getSortValue() === 'random' && this.currentRandomSeed) {
+        if (sort === 'random' && this.currentRandomSeed) {
             params.set('seed', this.currentRandomSeed);
         }
     }
@@ -343,7 +338,6 @@ class BaseGallery {
     addSortOption(value, label) {
         if (this.sortBySelects) {
             this.sortBySelects.forEach(select => select.addOption(value, label));
-            this.updateSortDisplay();
         }
     }
 

--- a/frontend/static/js/components/base-gallery.js
+++ b/frontend/static/js/components/base-gallery.js
@@ -6,7 +6,6 @@ class BaseGallery {
             popularTagsSelector: '#popular-tags',
             pageNavSelector: '#page-nav',
             sortBySelector: '#sort-by-select',
-            sortOrderSelector: '#sort-order-select',
             enableTooltips: true,
             enablePagination: true,
             enableRatingFilter: true,
@@ -24,7 +23,7 @@ class BaseGallery {
         this.tagCounts = new Map();
         this.tooltipHelper = null;
         this.sortBySelect = null;
-        this.sortOrderSelect = null;
+        this.currentRandomSeed = null;
 
         // Selection state
         this.lastSelectedId = null;
@@ -40,8 +39,7 @@ class BaseGallery {
             loading: document.querySelector(this.options.loadingSelector),
             popularTags: document.querySelector(this.options.popularTagsSelector),
             pageNav: document.querySelector(this.options.pageNavSelector),
-            sortBy: document.querySelector(this.options.sortBySelector),
-            sortOrder: document.querySelector(this.options.sortOrderSelector)
+            sortBy: document.querySelector(this.options.sortBySelector)
         };
 
         // Current state
@@ -54,8 +52,10 @@ class BaseGallery {
             this.currentCustomFilter = '';
         }
 
-        this.currentSort = this.elements.sortBy?.dataset.value || this.options.defaultSort;
-        this.currentOrder = this.elements.sortOrder?.dataset.value || this.options.defaultOrder;
+        const urlParams = new URLSearchParams(window.location.search);
+        this.currentSort = urlParams.get('sort') || this.elements.sortBy?.dataset.value || this.options.defaultSort;
+        this.currentOrder = urlParams.get('order') || this.options.defaultOrder;
+        this.currentRandomSeed = urlParams.get('seed') || null;
     }
 
     /**
@@ -201,56 +201,42 @@ class BaseGallery {
         }
 
         this.sortBySelects = [];
-        this.sortOrderSelects = [];
 
-        // 1. Setup Sort By Selects
         const sortByElements = document.querySelectorAll('.js-sort-by-select');
         const params = new URLSearchParams(window.location.search);
 
         sortByElements.forEach(element => {
             const select = new CustomSelect(element);
 
-            // Set initial value from URL if present
             if (params.has('sort')) {
                 select.setValue(params.get('sort'));
             }
 
-            // Sync changes to other instances and reload
             element.addEventListener('change', (e) => {
                 const newValue = e.detail.value;
                 this.sortBySelects.forEach(s => {
-                    if (s !== select) s.setValue(newValue);
+                    if (s !== select) s.setValue(newValue, false);
                 });
-                this.onSortChange();
+                this.handleSortSelection(newValue);
+            });
+
+            select.dropdown.querySelectorAll('.custom-select-option').forEach(option => {
+                if (!option.dataset.baseLabel) {
+                    option.dataset.baseLabel = option.textContent.trim();
+                }
             });
 
             this.sortBySelects.push(select);
         });
 
-        // 2. Setup Sort Order Selects
-        const sortOrderElements = document.querySelectorAll('.js-sort-order-select');
-
-        sortOrderElements.forEach(element => {
-            const select = new CustomSelect(element);
-
-            if (params.has('order')) {
-                select.setValue(params.get('order'));
-            }
-
-            element.addEventListener('change', (e) => {
-                const newValue = e.detail.value;
-                this.sortOrderSelects.forEach(s => {
-                    if (s !== select) s.setValue(newValue);
-                });
-                this.onSortChange();
-            });
-
-            this.sortOrderSelects.push(select);
-        });
-
-        // Backwards compatibility for single access
         this.sortBySelect = this.sortBySelects[0];
-        this.sortOrderSelect = this.sortOrderSelects[0];
+
+        if (this.currentSort === 'random' && !this.currentRandomSeed) {
+            this.currentRandomSeed = String(Date.now());
+            this.syncSortUrlParams();
+        }
+
+        this.updateSortDisplay();
     }
 
     getSortValue() {
@@ -261,22 +247,103 @@ class BaseGallery {
     }
 
     getOrderValue() {
-        if (this.sortOrderSelects && this.sortOrderSelects.length > 0) {
-            return this.sortOrderSelects[0].getValue();
-        }
         return this.currentOrder;
     }
 
+    handleSortSelection(newSort) {
+        const previousSort = this.currentSort;
+
+        if (newSort === previousSort) {
+            if (newSort === 'random') {
+                this.currentRandomSeed = String(Date.now());
+            } else {
+                this.currentOrder = this.currentOrder === 'asc' ? 'desc' : 'asc';
+            }
+        } else {
+            this.currentSort = newSort;
+            if (newSort === 'random') {
+                this.currentRandomSeed = String(Date.now());
+            } else {
+                this.currentRandomSeed = null;
+                this.currentOrder = 'desc';
+            }
+        }
+
+        this.updateSortDisplay();
+        this.syncSortUrlParams();
+        this.onSortChange();
+    }
+
+    getSortOrderIndicator(order) {
+        return order === 'asc' ? '↑' : '↓';
+    }
+
+    getSortBaseLabel(option) {
+        return option.dataset.baseLabel || option.textContent.trim();
+    }
+
+    formatSortLabel(baseLabel, sortValue, order, previewNext = false) {
+        if (sortValue === 'random') {
+            return previewNext ? `${baseLabel} ↻` : baseLabel;
+        }
+        const displayOrder = previewNext
+            ? (order === 'asc' ? 'desc' : 'asc')
+            : order;
+        return `${baseLabel} ${this.getSortOrderIndicator(displayOrder)}`;
+    }
+
+    updateSortDisplay() {
+        if (!this.sortBySelects) return;
+
+        this.sortBySelects.forEach(select => {
+            select.dropdown.querySelectorAll('.custom-select-option').forEach(option => {
+                const baseLabel = this.getSortBaseLabel(option);
+                const value = option.dataset.value;
+
+                if (value === this.currentSort) {
+                    option.textContent = this.formatSortLabel(
+                        baseLabel, value, this.currentOrder, true
+                    );
+                } else {
+                    option.textContent = baseLabel;
+                }
+            });
+
+            const currentOption = select.dropdown.querySelector(`[data-value="${this.currentSort}"]`);
+            if (currentOption) {
+                const baseLabel = this.getSortBaseLabel(currentOption);
+                select.valueDisplay.textContent = this.formatSortLabel(
+                    baseLabel, this.currentSort, this.currentOrder, false
+                );
+            }
+        });
+    }
+
+    syncSortUrlParams() {
+        const params = {
+            sort: this.currentSort,
+            order: this.currentOrder,
+            seed: this.currentRandomSeed
+        };
+        this.updateUrlParams(params);
+    }
+
+    appendSortParams(params) {
+        params.set('sort', this.getSortValue());
+        params.set('order', this.getOrderValue());
+        if (this.getSortValue() === 'random' && this.currentRandomSeed) {
+            params.set('seed', this.currentRandomSeed);
+        }
+    }
+
     onSortChange() {
-        this.currentSort = this.getSortValue();
-        this.currentOrder = this.getOrderValue();
-        this.updateUrlParams({ sort: this.currentSort, order: this.currentOrder });
         this.loadContent();
     }
 
     addSortOption(value, label) {
         if (this.sortBySelects) {
             this.sortBySelects.forEach(select => select.addOption(value, label));
+            this.updateSortDisplay();
         }
     }
 

--- a/frontend/static/js/components/base-gallery.js
+++ b/frontend/static/js/components/base-gallery.js
@@ -245,6 +245,9 @@ class BaseGallery {
 
         this.updateSortControlsVisibility();
         this.updateSortOrderToggleState();
+        if (this.currentSort === 'random') {
+            this.rollSortRandomDice();
+        }
     }
 
     getSortValue() {
@@ -266,6 +269,7 @@ class BaseGallery {
             if (previousSort !== 'random' || !this.currentRandomSeed) {
                 this.currentRandomSeed = String(Date.now());
             }
+            this.rollSortRandomDice();
         } else {
             this.currentRandomSeed = null;
         }
@@ -288,8 +292,17 @@ class BaseGallery {
         if (this.currentSort !== 'random') return;
 
         this.currentRandomSeed = String(Date.now());
+        this.rollSortRandomDice();
         this.syncSortUrlParams();
         this.onSortChange();
+    }
+
+    rollSortRandomDice() {
+        if (typeof renderDiceIcon === 'undefined') return;
+
+        this.sortRandomRegenBtns.forEach(btn => {
+            btn.innerHTML = renderDiceIcon();
+        });
     }
 
     updateSortControlsVisibility() {

--- a/frontend/static/js/components/custom-select.js
+++ b/frontend/static/js/components/custom-select.js
@@ -201,6 +201,7 @@ class CustomSelect {
         const option = document.createElement('div');
         option.className = 'custom-select-option px-3 py-2 cursor-pointer hover:surface text text-xs';
         option.dataset.value = value;
+        option.dataset.baseLabel = text;
         option.textContent = text;
 
         this._bindOptionEvents(option);

--- a/frontend/static/js/components/custom-select.js
+++ b/frontend/static/js/components/custom-select.js
@@ -6,6 +6,8 @@ class CustomSelect {
         this.valueDisplay = element.querySelector('.custom-select-value');
         this.selectedValue = element.dataset.value || '';
         this.focusedIndex = -1;
+        this.disabled = false;
+        this.arrow = element.querySelector('.custom-select-arrow');
 
         this.init();
         this.initializeExistingOptions();
@@ -13,6 +15,7 @@ class CustomSelect {
 
     init() {
         this.trigger.addEventListener('click', (e) => {
+            if (this.disabled) return;
             e.stopPropagation();
             this.toggle();
         });
@@ -57,6 +60,8 @@ class CustomSelect {
     }
 
     toggle() {
+        if (this.disabled) return;
+
         if (this.element.classList.contains('open')) {
             this.close();
         } else {
@@ -65,6 +70,8 @@ class CustomSelect {
     }
 
     open() {
+        if (this.disabled) return;
+
         document.querySelectorAll('.custom-select.open').forEach(select => {
             if (select !== this.element) {
                 select.classList.remove('open');
@@ -108,6 +115,8 @@ class CustomSelect {
     }
 
     handleKeyboard(e) {
+        if (this.disabled) return;
+
         const isOpen = this.element.classList.contains('open');
         const options = this.dropdown.querySelectorAll('.custom-select-option');
 
@@ -182,6 +191,33 @@ class CustomSelect {
 
     getValue() {
         return this.selectedValue;
+    }
+
+    setDisabled(disabled) {
+        this.disabled = disabled;
+        this.trigger.disabled = disabled;
+
+        if (disabled) {
+            this.trigger.classList.remove('bg', 'hover:border-primary', 'focus:border-primary', 'cursor-pointer');
+            this.trigger.classList.add('surface', 'cursor-not-allowed');
+            this.valueDisplay.classList.remove('text');
+            this.valueDisplay.classList.add('text-tertiary');
+            if (this.arrow) {
+                this.arrow.classList.remove('text-secondary');
+                this.arrow.classList.add('text-tertiary');
+            }
+            this.close();
+            return;
+        }
+
+        this.trigger.classList.add('bg', 'hover:border-primary', 'focus:border-primary', 'cursor-pointer');
+        this.trigger.classList.remove('surface', 'cursor-not-allowed');
+        this.valueDisplay.classList.add('text');
+        this.valueDisplay.classList.remove('text-tertiary');
+        if (this.arrow) {
+            this.arrow.classList.add('text-secondary');
+            this.arrow.classList.remove('text-tertiary');
+        }
     }
 
     setOptions(optionsData) {

--- a/frontend/static/js/components/dice-icon.js
+++ b/frontend/static/js/components/dice-icon.js
@@ -1,0 +1,15 @@
+const DICE_FACE_DOTS = {
+    1: '<circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"></circle>',
+    2: '<circle cx="8" cy="8" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="16" cy="16" r="1.5" fill="currentColor" stroke="none"></circle>',
+    3: '<circle cx="8" cy="8" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="16" cy="16" r="1.5" fill="currentColor" stroke="none"></circle>',
+    4: '<circle cx="8" cy="8" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="16" cy="8" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="8" cy="16" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="16" cy="16" r="1.5" fill="currentColor" stroke="none"></circle>',
+    5: '<circle cx="8" cy="8" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="16" cy="8" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="8" cy="16" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="16" cy="16" r="1.5" fill="currentColor" stroke="none"></circle>',
+    6: '<circle cx="8" cy="8" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="16" cy="8" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="8" cy="12" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="16" cy="12" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="8" cy="16" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="16" cy="16" r="1.5" fill="currentColor" stroke="none"></circle>'
+};
+
+function renderDiceIcon(face) {
+    const resolvedFace = face || Math.floor(Math.random() * 6) + 1;
+    const dots = DICE_FACE_DOTS[resolvedFace] || DICE_FACE_DOTS[1];
+
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect>${dots}</svg>`;
+}

--- a/frontend/static/js/pages/album.js
+++ b/frontend/static/js/pages/album.js
@@ -84,10 +84,9 @@ class AlbumViewer extends BaseGallery {
         try {
             const params = new URLSearchParams({
                 page: this.currentPage,
-                rating: this.currentRating,
-                sort: this.getSortValue(),
-                order: this.getOrderValue()
+                rating: this.currentRating
             });
+            this.appendSortParams(params);
 
             if (this.currentCustomFilter) {
                 params.set('q', this.currentCustomFilter);
@@ -149,13 +148,6 @@ class AlbumViewer extends BaseGallery {
     onRatingChange() {
         this.loadContent();
         this.loadPopularTagsFromAPI();
-    }
-
-    onSortChange() {
-        this.currentSort = this.getSortValue();
-        this.currentOrder = this.getOrderValue();
-        this.updateUrlParams({ sort: this.currentSort, order: this.currentOrder });
-        this.loadContent();
     }
 
     renderContents(data) {

--- a/frontend/static/js/pages/albums.js
+++ b/frontend/static/js/pages/albums.js
@@ -29,11 +29,10 @@ class AlbumsOverview extends BaseGallery {
         try {
             const params = new URLSearchParams({
                 page: this.currentPage,
-                sort: this.getSortValue(),
-                order: this.getOrderValue(),
                 root_only: 'true',
                 rating: this.currentRating
             });
+            this.appendSortParams(params);
 
             const response = await fetch(`/api/albums?${params}`);
             if (!response.ok) throw new Error(window.i18n.t('albums.failed_load_list'));

--- a/frontend/static/js/pages/gallery.js
+++ b/frontend/static/js/pages/gallery.js
@@ -1,8 +1,7 @@
 class Gallery extends BaseGallery {
     constructor() {
         super({
-            gridSelector: '#gallery-grid',
-            defaultSort: 'uploaded_at'
+            gridSelector: '#gallery-grid'
         });
 
         if (this.elements.grid) {

--- a/frontend/static/js/pages/gallery.js
+++ b/frontend/static/js/pages/gallery.js
@@ -40,8 +40,7 @@ class Gallery extends BaseGallery {
             // 1. Basic pagination and filters
             apiParams.set('page', this.currentPage);
             apiParams.set('rating', this.currentRating);
-            apiParams.set('sort', this.getSortValue());
-            apiParams.set('order', this.getOrderValue());
+            this.appendSortParams(apiParams);
 
             // 2. Handle Search vs Browse
             const urlParams = new URLSearchParams(window.location.search);

--- a/frontend/static/locales/en.json
+++ b/frontend/static/locales/en.json
@@ -603,7 +603,9 @@
         "selecting_all": "Selecting All...",
         "sort_by": "Sort By",
         "sort_random": "Random",
-        "sort_tag_count": "# of Tags"
+        "sort_regen_random": "Shuffle again",
+        "sort_tag_count": "# of Tags",
+        "sort_toggle_order": "Toggle sort order"
     },
     "login": {
         "enter_credentials": "Enter your credentials to access {app_name}",

--- a/frontend/static/locales/en.json
+++ b/frontend/static/locales/en.json
@@ -601,7 +601,9 @@
         "remove_from_album": "Remove from Album",
         "select_all": "Select All",
         "selecting_all": "Selecting All...",
-        "sort_by": "Sort By"
+        "sort_by": "Sort By",
+        "sort_random": "Random",
+        "sort_tag_count": "# of Tags"
     },
     "login": {
         "enter_credentials": "Enter your credentials to access {app_name}",

--- a/frontend/static/locales/ru.json
+++ b/frontend/static/locales/ru.json
@@ -601,7 +601,9 @@
         "remove_from_album": "Удалить из альбома",
         "select_all": "Выбрать все",
         "selecting_all": "Выбираем все...",
-        "sort_by": "Сортировать по"
+        "sort_by": "Сортировать по",
+        "sort_random": "",
+        "sort_tag_count": ""
     },
     "login": {
         "enter_credentials": "Введите свои учетные данные для доступа к {app_name}",

--- a/frontend/static/locales/ru.json
+++ b/frontend/static/locales/ru.json
@@ -603,7 +603,9 @@
         "selecting_all": "Выбираем все...",
         "sort_by": "Сортировать по",
         "sort_random": "",
-        "sort_tag_count": ""
+        "sort_regen_random": "",
+        "sort_tag_count": "",
+        "sort_toggle_order": ""
     },
     "login": {
         "enter_credentials": "Введите свои учетные данные для доступа к {app_name}",

--- a/frontend/static/locales/sv.json
+++ b/frontend/static/locales/sv.json
@@ -603,7 +603,9 @@
         "selecting_all": "Väljer alla...",
         "sort_by": "Sortera efter",
         "sort_random": "",
-        "sort_tag_count": ""
+        "sort_regen_random": "",
+        "sort_tag_count": "",
+        "sort_toggle_order": ""
     },
     "login": {
         "enter_credentials": "Ange dina uppgifter för att komma åt {app_name}",

--- a/frontend/static/locales/sv.json
+++ b/frontend/static/locales/sv.json
@@ -601,7 +601,9 @@
         "remove_from_album": "Ta bort från album",
         "select_all": "Välj alla",
         "selecting_all": "Väljer alla...",
-        "sort_by": "Sortera efter"
+        "sort_by": "Sortera efter",
+        "sort_random": "",
+        "sort_tag_count": ""
     },
     "login": {
         "enter_credentials": "Ange dina uppgifter för att komma åt {app_name}",

--- a/frontend/static/locales/zh-cn.json
+++ b/frontend/static/locales/zh-cn.json
@@ -601,7 +601,9 @@
         "remove_from_album": "从相册中移除",
         "select_all": "全选",
         "selecting_all": "正在全选...",
-        "sort_by": "排序方式"
+        "sort_by": "排序方式",
+        "sort_random": "",
+        "sort_tag_count": ""
     },
     "login": {
         "enter_credentials": "输入您的凭据以访问 {app_name}",

--- a/frontend/static/locales/zh-cn.json
+++ b/frontend/static/locales/zh-cn.json
@@ -603,7 +603,9 @@
         "selecting_all": "正在全选...",
         "sort_by": "排序方式",
         "sort_random": "",
-        "sort_tag_count": ""
+        "sort_regen_random": "",
+        "sort_tag_count": "",
+        "sort_toggle_order": ""
     },
     "login": {
         "enter_credentials": "输入您的凭据以访问 {app_name}",

--- a/frontend/static/sw.js
+++ b/frontend/static/sw.js
@@ -24,6 +24,7 @@ const STATIC_ASSETS = [
     '/static/js/components/fullscreen-mediaviewer.js',
     '/static/js/components/media-viewer-base.js',
     '/static/js/components/media-picker-modal.js',
+    '/static/js/components/dice-icon.js',
     '/static/js/components/base-gallery.js',
     '/static/js/bulk/bulk-tag-modal-base.js',
     '/static/js/bulk/bulk-manage-tags-modal.js',

--- a/frontend/templates/admin/system.html
+++ b/frontend/templates/admin/system.html
@@ -98,6 +98,10 @@
                                         data-value="file_size">{{ t('admin.settings.file_size') }}</div>
                                     <div class="custom-select-option px-3 py-2 cursor-pointer hover:surface text-xs"
                                         data-value="file_type">{{ t('admin.settings.file_type') }}</div>
+                                    <div class="custom-select-option px-3 py-2 cursor-pointer hover:surface text-xs"
+                                        data-value="tag_count">{{ t('gallery.sort_tag_count') }}</div>
+                                    <div class="custom-select-option px-3 py-2 cursor-pointer hover:surface text-xs"
+                                        data-value="random">{{ t('gallery.sort_random') }}</div>
                                 </div>
                             </div>
                             <div id="default-order" class="custom-select w-full" data-value="desc">

--- a/frontend/templates/album.html
+++ b/frontend/templates/album.html
@@ -73,6 +73,7 @@ loading_indicator, page_navigation, popular_tags_section, sidebar_start, sidebar
 <script src="/static/js/bulk/bulk-ai-tags-modal.js?v={{ cache_buster }}"></script>
 <script src="/static/js/bulk/bulk-wd-tagger-modal.js?v={{ cache_buster }}"></script>
 <script src="/static/js/bulk/bulk-rating-modal.js?v={{ cache_buster }}"></script>
+<script src="/static/js/components/dice-icon.js?v={{ cache_buster }}"></script>
 <script src="/static/js/components/base-gallery.js?v={{ cache_buster }}"></script>
 <script src="/static/js/pages/album.js?v={{ cache_buster }}"></script>
 {% endblock %}

--- a/frontend/templates/albums.html
+++ b/frontend/templates/albums.html
@@ -46,6 +46,7 @@ loading_indicator, page_navigation, sidebar_start, sidebar_end %}
 {% block extra_js %}
 <script src="/static/js/components/tooltip-helper.js?v={{ cache_buster }}"></script>
 <script src="/static/js/components/custom-select.js?v={{ cache_buster }}"></script>
+<script src="/static/js/components/dice-icon.js?v={{ cache_buster }}"></script>
 <script src="/static/js/components/base-gallery.js?v={{ cache_buster }}"></script>
 <script src="/static/js/pages/albums.js?v={{ cache_buster }}"></script>
 {% endblock %}

--- a/frontend/templates/albums.html
+++ b/frontend/templates/albums.html
@@ -8,7 +8,8 @@ loading_indicator, page_navigation, sidebar_start, sidebar_end %}
 {% set album_sort_options = {
     'uploaded_at': t('admin.settings.upload_date'),
     'last_modified': t('albums.sort_last_modified'),
-    'filename': t('admin.settings.file_name')
+    'filename': t('admin.settings.file_name'),
+    'random': t('gallery.sort_random')
 } %}
 <div class="container mx-auto px-4 py-4">
     <div class="grid grid-cols-1 xl:grid-cols-5 lg:grid-cols-4 gap-4">

--- a/frontend/templates/albums.html
+++ b/frontend/templates/albums.html
@@ -5,12 +5,17 @@ loading_indicator, page_navigation, sidebar_start, sidebar_end %}
 {% block title %}{{ t('common.albums') }} - {{ app_name }}{% endblock %}
 
 {% block content %}
+{% set album_sort_options = {
+    'uploaded_at': t('admin.settings.upload_date'),
+    'last_modified': t('albums.sort_last_modified'),
+    'filename': t('admin.settings.file_name')
+} %}
 <div class="container mx-auto px-4 py-4">
     <div class="grid grid-cols-1 xl:grid-cols-5 lg:grid-cols-4 gap-4">
         <!-- Albums Grid -->
         <div class="xl:col-span-4 lg:col-span-3">
             {{ rating_filter('mobile', mode=sidebar_filter_mode, custom_buttons=sidebar_custom_buttons) }}
-            {{ sorting_options(default_sort=default_sort, default_order=default_order, location='mobile') }}
+            {{ sorting_options(sort_options=album_sort_options, default_sort=default_sort, default_order=default_order, location='mobile') }}
 
             <div id="albums-grid"
                 class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-8 gap-2">
@@ -23,7 +28,7 @@ loading_indicator, page_navigation, sidebar_start, sidebar_end %}
         <!-- Sidebar -->
         {{ sidebar_start() }}
         {{ rating_filter('desktop', mode=sidebar_filter_mode, custom_buttons=sidebar_custom_buttons) }}
-        {{ sorting_options(default_sort=default_sort, default_order=default_order) }}
+        {{ sorting_options(sort_options=album_sort_options, default_sort=default_sort, default_order=default_order) }}
 
         <h3 class="text-sm font-bold mb-2 pb-1 border-b">{{ t('gallery.popular_tags') }}</h3>
         <div id="popular-tags" class="text-xs">

--- a/frontend/templates/components/macros.html
+++ b/frontend/templates/components/macros.html
@@ -119,6 +119,7 @@ location='desktop') %}
                     </button>
                     <button id="sort-random-regen{{ suffix }}" type="button"
                         class="js-sort-random-regen sort-random-regen p-1 border bg text hover:border-primary transition-colors flex-shrink-0 hidden"
+                        aria-label="{{ t('gallery.sort_regen_random') }}"
                         title="{{ t('gallery.sort_regen_random') }}">
                         {{ dice_icon() }}
                     </button>

--- a/frontend/templates/components/macros.html
+++ b/frontend/templates/components/macros.html
@@ -69,14 +69,15 @@ location='desktop') %}
 'uploaded_at': t('admin.settings.upload_date'),
 'filename': t('admin.settings.file_name'),
 'file_size': t('admin.settings.file_size'),
-'file_type': t('admin.settings.file_type')
+'file_type': t('admin.settings.file_type'),
+'tag_count': t('gallery.sort_tag_count'),
+'random': t('gallery.sort_random')
 } %}
 {% set options = sort_options if sort_options else standard_sort_options %}
 {% set suffix = '-mobile' if location == 'mobile' else '' %}
 
 {% if location == 'mobile' %}
 <div class="surface p-3 mb-4 border block lg:hidden">
-    <div class="grid grid-cols-2 gap-2">
         {% elif show_wrapper %}
         <div class="hidden lg:block mb-4">
             <h3 class="text-sm font-bold mb-3 pb-1 border-b">{{ t('gallery.sort_by') }}</h3>
@@ -98,32 +99,8 @@ location='desktop') %}
                         style="z-index: 50;">
                         {% for value, label in options.items() %}
                         <div class="custom-select-option px-3 py-2 cursor-pointer hover:surface text-xs transition-colors"
-                            data-value="{{ value }}">{{ label }}</div>
+                            data-value="{{ value }}" data-base-label="{{ label }}">{{ label }}</div>
                         {% endfor %}
-                    </div>
-                </div>
-
-                <div id="sort-order-select{{ suffix }}" class="custom-select js-sort-order-select w-full"
-                    data-value="{{ default_order }}">
-                    <button
-                        class="custom-select-trigger w-full flex items-center justify-between gap-3 px-2 py-1 bg border text-xs cursor-pointer hover:border-primary focus:outline-none focus:border-primary transition-colors"
-                        type="button">
-                        <span class="custom-select-value text">
-                            {{ t('admin.settings.descending') if default_order == 'desc' else
-                            t('admin.settings.ascending') }}
-                        </span>
-                        {{ _select_arrow() }}
-                    </button>
-                    <div class="custom-select-dropdown bg border border-primary max-h-60 overflow-y-auto shadow-lg"
-                        style="z-index: 50;">
-                        <div class="custom-select-option px-3 py-2 cursor-pointer hover:surface text-xs transition-colors"
-                            data-value="desc">
-                            {{ t('admin.settings.descending') }}
-                        </div>
-                        <div class="custom-select-option px-3 py-2 cursor-pointer hover:surface text-xs transition-colors"
-                            data-value="asc">
-                            {{ t('admin.settings.ascending') }}
-                        </div>
                     </div>
                 </div>
 
@@ -131,7 +108,6 @@ location='desktop') %}
             </div>
             {% endif %}
             {% if location == 'mobile' %}
-        </div>
     </div>
     {% elif show_wrapper %}
 </div>

--- a/frontend/templates/components/macros.html
+++ b/frontend/templates/components/macros.html
@@ -63,6 +63,7 @@
 
 
 {# Sorting Options Component #}
+{% from "components/icons.html" import dice_icon %}
 {% macro sorting_options(sort_options=none, default_sort='uploaded_at', default_order='desc', show_wrapper=true,
 location='desktop') %}
 {% set standard_sort_options = {
@@ -83,25 +84,44 @@ location='desktop') %}
             <h3 class="text-sm font-bold mb-3 pb-1 border-b">{{ t('gallery.sort_by') }}</h3>
             {% endif %}
 
-            {% if location != 'mobile' %}<div class="mb-3 flex flex-wrap gap-2">{% endif %}
+            {% if location != 'mobile' %}<div class="mb-3">{% endif %}
 
-                <div id="sort-by-select{{ suffix }}" class="custom-select js-sort-by-select w-full"
-                    data-value="{{ default_sort }}">
-                    <button
-                        class="custom-select-trigger w-full flex items-center justify-between gap-3 px-2 py-1 bg border text-xs cursor-pointer hover:border-primary focus:outline-none focus:border-primary transition-colors"
-                        type="button">
-                        <span class="custom-select-value text">
-                            {{ options[default_sort] if default_sort in options else options.values()|first }}
-                        </span>
-                        {{ _select_arrow() }}
-                    </button>
-                    <div class="custom-select-dropdown bg border border-primary max-h-60 overflow-y-auto shadow-lg"
-                        style="z-index: 50;">
-                        {% for value, label in options.items() %}
-                        <div class="custom-select-option px-3 py-2 cursor-pointer hover:surface text-xs transition-colors"
-                            data-value="{{ value }}" data-base-label="{{ label }}">{{ label }}</div>
-                        {% endfor %}
+                <div id="sort-controls{{ suffix }}" class="js-sort-controls flex gap-2 w-full items-stretch"
+                    data-default-order="{{ default_order }}">
+                    <div id="sort-by-select{{ suffix }}" class="custom-select js-sort-by-select flex-1 min-w-0"
+                        data-value="{{ default_sort }}">
+                        <button
+                            class="custom-select-trigger w-full flex items-center justify-between gap-3 px-2 py-1 bg border text-xs cursor-pointer hover:border-primary focus:outline-none focus:border-primary transition-colors"
+                            type="button">
+                            <span class="custom-select-value text">
+                                {{ options[default_sort] if default_sort in options else options.values()|first }}
+                            </span>
+                            {{ _select_arrow() }}
+                        </button>
+                        <div class="custom-select-dropdown bg border border-primary max-h-60 overflow-y-auto shadow-lg"
+                            style="z-index: 50;">
+                            {% for value, label in options.items() %}
+                            <div class="custom-select-option px-3 py-2 cursor-pointer hover:surface text-xs transition-colors"
+                                data-value="{{ value }}">{{ label }}</div>
+                            {% endfor %}
+                        </div>
                     </div>
+                    <button id="sort-order-toggle{{ suffix }}" type="button"
+                        class="js-sort-order-toggle sort-order-toggle p-1 border bg text hover:border-primary transition-colors flex-shrink-0 {{ default_order }}"
+                        data-order="{{ default_order }}"
+                        aria-label="{{ t('gallery.sort_toggle_order') }}"
+                        title="{{ t('gallery.sort_toggle_order') }}">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="sort-order-chevron">
+                            <polyline points="6 9 12 15 18 9"></polyline>
+                        </svg>
+                    </button>
+                    <button id="sort-random-regen{{ suffix }}" type="button"
+                        class="js-sort-random-regen sort-random-regen p-1 border bg text hover:border-primary transition-colors flex-shrink-0 hidden"
+                        title="{{ t('gallery.sort_regen_random') }}">
+                        {{ dice_icon() }}
+                    </button>
                 </div>
 
                 {% if location != 'mobile' %}

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -46,6 +46,7 @@ loading_indicator, page_navigation, popular_tags_section, sidebar_start, sidebar
 <script src="/static/js/bulk/bulk-ai-tags-modal.js?v={{ cache_buster }}"></script>
 <script src="/static/js/bulk/bulk-rating-modal.js?v={{ cache_buster }}"></script>
 <script src="/static/js/bulk/bulk-wd-tagger-modal.js?v={{ cache_buster }}"></script>
+<script src="/static/js/components/dice-icon.js?v={{ cache_buster }}"></script>
 <script src="/static/js/components/base-gallery.js?v={{ cache_buster }}"></script>
 <script src="/static/js/pages/gallery.js?v={{ cache_buster }}"></script>
 {% endblock %}


### PR DESCRIPTION
Note: Re-submission of earlier PR with issues corrected:
- Split into it's own specific branch and commit
- New localization strings are entered for English, and entered _blank_ for other locales.

## What does this PR do?
Enhanced sorting in a few ways:
- Adds option to sort by number of tags
- Adds option to sort randomly
- Folds the ordering (ascending/descending) behavior into sorting for simplicity. Re-selecting the same sort again will flip the order (except for random sort, where re-selecting will re-seed to a new random order)

## Checklist
- [ X ] I have read the [Contributing Guidelines](https://github.com/mrblomblo/blombooru/blob/main/CONTRIBUTING.md).
- [ X ] I have tested my changes and confirmed that Blombooru starts up and works as expected.
- [ X ] My PR addresses one thing only.
- [ X ] I have not broken any existing functionality.

## Screenshots
<img width="275" height="274" alt="blom_sort_new" src="https://github.com/user-attachments/assets/a7333e23-37b4-4af0-b0a3-5c62079b4d48" />

## Additional context
- Behind the scenes, implemented media_sort.py helper and updated touch points where sort is presented/applied (albums, media, search).
- Random ordering is pagination compatible. We store a seed value for the random sort each time it's initiated so we can be consistent as we move between pages. Re-selecting the 'Random' option in the sort options will trigger a fresh seed.
- Folding ordering into sorting was partly for simplicity (it's intuitive to just flip ordering by re-selecting the same sort a second time) and partly out of necessity (When selecting random sort, having an additional option for asc/desc ordering doesn't make sense.
- Sorts are db selects, not in-memory.

Purpose of these changes:
- Sorting by number of tags easily answers 'what items need tagging'
- Sorting randomly brings gallery-level parity to the 'I'm Feeling Lucky' dice roll.
