### PR TITLE
Add descriptions to backup archives

### DIFF
--- a/backend/app/routes/admin/backup.py
+++ b/backend/app/routes/admin/backup.py
@@ -111,6 +111,7 @@ async def backup_full_db(
             "height": m.height,
             "duration": m.duration,
             "rating": m.rating.value if m.rating else 'safe',
+            "description": m.description,
             "tags": [t.name for t in m.tags],
             "archive_path": archive_path,
             "parent_hash": m.parent.hash if m.parent else None

--- a/backend/app/utils/backup.py
+++ b/backend/app/utils/backup.py
@@ -317,7 +317,8 @@ def import_media_logical(db: Session, zf: zipfile.ZipFile, media_list: List[dict
             width=media_data.get('width'),
             height=media_data.get('height'),
             duration=media_data.get('duration'),
-            rating=media_data.get('rating', 'safe')
+            rating=media_data.get('rating', 'safe'),
+            description=media_data.get('description')
         )
         db.add(new_media)
         db.flush() # Get ID


### PR DESCRIPTION
## What does this PR do?

Adds a description field to backup archives.

## Checklist
> [!IMPORTANT]
> Go through and check these before submitting.

- [X] I have read the [Contributing Guidelines](https://github.com/mrblomblo/blombooru/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes and confirmed that Blombooru starts up and works as expected.
- [X] My PR addresses one thing only (e.g., `Fixes #40` or `Adds #41`, not `Fixes #40 and adds #41`).
- [X] I have not broken any existing functionality (or I have explained why the change was necessary below).

## Screenshots
<!-- If applicable, add screenshots here. Required for theme PRs and UI changes. For theme updates, include before/after screenshots. -->
N/A

## Additional context
Tested backup export, which properly stores descriptions inside the json file. Also tested import of two backup files that did and didn't have a description field to check backwards compatibility, seems to have imported properly in either case.

Haven't worked with open source before so let me know if I did anything wrong. But this seemed like a pretty small change so I figured I'd give it a go instead of submitting an issue