### PR TITLE
Fix: Removed chunked downloading for one-shot download requests

### DIFF
--- a/backend/app/routes/media.py
+++ b/backend/app/routes/media.py
@@ -582,7 +582,7 @@ async def get_media(media_id: int, db: Session = Depends(get_db)):
     return result
 
 @router.get("/{media_id}/file")
-async def get_media_file(media_id: int):
+async def get_media_file(media_id: int, chunked: bool = False):
     """Serve media file"""
     db = next(get_db())
     try:
@@ -594,7 +594,7 @@ async def get_media_file(media_id: int):
     finally:
         db.close()
 
-    return await serve_media_file(file_path, mime_type)
+    return await serve_media_file(file_path, mime_type, chunked=chunked)
 
 @router.get("/{media_id}/thumbnail")
 async def get_media_thumbnail(media_id: int):

--- a/backend/app/routes/sharing.py
+++ b/backend/app/routes/sharing.py
@@ -38,7 +38,7 @@ async def get_shared_content(share_uuid: str, request: Request, db: Session = De
     raise HTTPException(status_code=404, detail="Shared content not found")
 
 @router.get("/{share_uuid}/file")
-async def get_shared_file(share_uuid: str, request: Request):
+async def get_shared_file(share_uuid: str, request: Request, chunked: bool = False):
     """Serve shared media file with metadata stripped if AI metadata not shared"""
     shared_limiter.check(request)
     db = next(get_db())
@@ -55,7 +55,7 @@ async def get_shared_file(share_uuid: str, request: Request):
     finally:
         db.close()
 
-    return await serve_media_file(file_path, mime_type, strip_metadata=strip_metadata)
+    return await serve_media_file(file_path, mime_type, strip_metadata=strip_metadata, chunked=chunked)
 
 @router.get("/{share_uuid}/thumbnail")
 async def get_shared_thumbnail(share_uuid: str, request: Request):

--- a/backend/app/utils/media_helpers.py
+++ b/backend/app/utils/media_helpers.py
@@ -341,9 +341,13 @@ async def create_stripped_media_cache(file_path: Path, mime_type: str) -> Option
         return None
 
 class ChunkedMediaResponse(FileResponse):
-    """FileResponse subclass with Range request capping and video-specific initial chunking."""
+    """FileResponse subclass with Range request capping and optional video initial chunking."""
     MAX_RANGE_SIZE = 25 * 1024 * 1024       # 25 MB
     INITIAL_VIDEO_CHUNK = 2 * 1024 * 1024   # 2 MB
+
+    def __init__(self, *args, chunked: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.chunked = chunked
 
     @staticmethod
     def _parse_range_header(http_range: str, file_size: int) -> list[tuple[int, int]]:
@@ -360,15 +364,21 @@ class ChunkedMediaResponse(FileResponse):
 
     async def __call__(self, scope, receive, send) -> None:
         headers = dict(scope.get("headers", []))
-        if b"range" not in headers:
-            # Inject a bounded initial range for videos to avoid connection starvation
+        # Opt-in: inject a bounded initial range for videos to avoid connection starvation
+        if self.chunked and b"range" not in headers:
             is_video = self.media_type and self.media_type.startswith("video/")
             if is_video:
                 end_byte = self.INITIAL_VIDEO_CHUNK - 1
                 scope["headers"].append((b"range", f"bytes=0-{end_byte}".encode()))
         await super().__call__(scope, receive, send)
 
-async def serve_media_file(file_path: Path, mime_type: str, error_message: str = "File not found", strip_metadata: bool = False) -> FileResponse:
+async def serve_media_file(
+    file_path: Path,
+    mime_type: str,
+    error_message: str = "File not found",
+    strip_metadata: bool = False,
+    chunked: bool = False,
+) -> FileResponse:
     """Serve a media file with error handling, optional metadata stripping, and browser caching."""
     if not file_path.exists():
         raise HTTPException(status_code=404, detail=error_message)
@@ -376,15 +386,15 @@ async def serve_media_file(file_path: Path, mime_type: str, error_message: str =
     cache_headers = {"Cache-Control": "public, max-age=31536000, immutable"}
     
     if not strip_metadata:
-        return ChunkedMediaResponse(file_path, media_type=mime_type, headers=cache_headers)
+        return ChunkedMediaResponse(file_path, media_type=mime_type, headers=cache_headers, chunked=chunked)
     
     if mime_type and mime_type.startswith('image/'):
         cache_path = await create_stripped_media_cache(file_path, mime_type)
         if cache_path:
-            return ChunkedMediaResponse(cache_path, media_type=mime_type, headers=cache_headers)
+            return ChunkedMediaResponse(cache_path, media_type=mime_type, headers=cache_headers, chunked=chunked)
     
     # Fallback to original file if stripping not supported or failed
-    return ChunkedMediaResponse(file_path, media_type=mime_type, headers=cache_headers)
+    return ChunkedMediaResponse(file_path, media_type=mime_type, headers=cache_headers, chunked=chunked)
 
 def delete_media_cache(file_path: Path):
     """Delete the cached version of a media file if it exists."""

--- a/docs/Internal API/API/Media.md
+++ b/docs/Internal API/API/Media.md
@@ -65,6 +65,10 @@ GET /api/media/{id}/file
 
 Streams the original media file.
 
+| Param | Type | Description |
+|---|---|---|
+| `chunked` | bool | Optional. When `true`, video responses without a `Range` header are limited to an initial 2MB chunk (for in-browser playback). Default `false` returns the full file. |
+
 ### Serve thumbnail
 
 ```

--- a/docs/Internal API/API/Shared Media.md
+++ b/docs/Internal API/API/Shared Media.md
@@ -34,6 +34,10 @@ GET /api/shared/{share_uuid}/file
 
 Streams the original media file. If `share_ai_metadata` is `false` on the share, EXIF/generation metadata is stripped on the fly before serving.
 
+| Param | Type | Description |
+|---|---|---|
+| `chunked` | bool | Optional. When `true`, video responses without a `Range` header are limited to an initial 2MB chunk (for in-browser playback). Default `false` returns the full file. |
+
 ### Serve shared thumbnail
 
 ```

--- a/frontend/static/js/bulk/bulk-tag-modal-base.js
+++ b/frontend/static/js/bulk/bulk-tag-modal-base.js
@@ -217,9 +217,9 @@ class BulkTagModalBase {
                         const index = parseInt(itemDiv.dataset.index);
                         const item = this.itemsData[index];
                         if (item && item.mediaId) {
-                            const src = `/api/media/${item.mediaId}/file`;
                             // Detect if video based on filename extension
                             const isVideo = item.filename && /\.(mp4|webm|mov|avi|mkv)$/i.test(item.filename);
+                            const src = `/api/media/${item.mediaId}/file${isVideo ? '?chunked=true' : ''}`;
                             this.fullscreenViewer.open(src, isVideo);
                         }
                     }

--- a/frontend/static/js/pages/media.js
+++ b/frontend/static/js/pages/media.js
@@ -222,7 +222,7 @@ class MediaViewer extends MediaViewerBase {
             video.loop = true;
 
             const source = document.createElement('source');
-            source.src = `/api/media/${media.id}/file${media.hash ? '?v=' + media.hash : ''}`;
+            source.src = `/api/media/${media.id}/file?chunked=true${media.hash ? '&v=' + media.hash : ''}`;
             source.type = media.mime_type;
 
             video.appendChild(source);

--- a/frontend/static/js/pages/shared.js
+++ b/frontend/static/js/pages/shared.js
@@ -194,7 +194,7 @@ class SharedViewer extends MediaViewerBase {
         if (media.file_type === 'video') {
             return `
                 <video controls loop id="shared-media-video" style="max-width: 100%; max-height: 80vh; margin: 0 auto;">
-                    <source src="/api/shared/${this.shareUuid}/file${media.hash ? '?v=' + media.hash : ''}" type="${media.mime_type}">
+                    <source src="/api/shared/${this.shareUuid}/file?chunked=true${media.hash ? '&v=' + media.hash : ''}" type="${media.mime_type}">
                 </video>
                 <div id="video-error" style="display: none;" class="flex flex-col items-center justify-center py-8 text-secondary">
                     <img src="/static/images/no-thumbnail.png" alt="${window.i18n.t('common.media_not_found')}" class="w-32 h-32 mb-4 opacity-50">


### PR DESCRIPTION
## What does this PR do?
Addresses #114 (Video file downloads truncated at 2MB)

The underlying problem was that download requests for video files were always being chunked by the API by default. When no range size was supplied in the request, it defaulted to a 2MB initial chunk. Since standard in-browser download methods are one-shot, the browser never requests subsequent chunks and just stops once 2MB of data has been received. This commit flips the logic on the API's download requests so that:
- By default the API will assume the client is one-shot and will serve the whole file.
- If the 'range' parameter OR the new 'chunked' parameter is received it'll follow the formerly-default chunking behavior.
- Front-end calls to the API for in-browser `video` serves now include the 'chunked' parameter, and so behave no differently to before.

The upshot of this is downloading should be fixed, and in-browser video should function the same as before. Any novel/naive calls to the download API endpoint will be assumed to be one-shot/dumb clients unless they include 'range' and/or 'chunked' parameters.

**Note:** I did consider just point fixing the download button by making that bear an additional parameter (e.g. `?download=1`), but decided it was best if the default behavior _assumes_ a crude client that can't/won't chunk it's requests. Burdening the more sophisticated requester with needing to pass additional parameters seemed the more robust approach.


## Checklist
- [ X ] I have read the [Contributing Guidelines](https://github.com/mrblomblo/blombooru/blob/main/CONTRIBUTING.md).
- [ X ] I have tested my changes and confirmed that Blombooru starts up and works as expected.
- [ X ] My PR addresses one thing only (e.g., `Fixes #40` or `Adds #41`, not `Fixes #40 and adds #41`).
- [ X ] I have not broken any existing functionality (or I have explained why the change was necessary below).

## Screenshots
N/A


## Additional context
Tested on dev install on local machine, confirmed:
- In-tab video embeds have ?chunked=true appended.
- In-tab image embeds do not.
- In-browser downloads using the 'Download' button for videos over 2MB now download fully.
- In-browser video embeds appear to follow the expected chunking behavior.
