### PR TITLE
Fix DLL loading for CUDA on Windows

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,20 @@ if os.name == 'posix':
             os.environ['LD_LIBRARY_PATH'] = f"{new_ld_path}:{current_ld_path}"
             os.execv(sys.executable, [sys.executable] + sys.argv)
 
+elif os.name == "nt":
+    try:
+        import onnxruntime as ort
+        if "CUDAExecutionProvider" in ort.get_available_providers():
+            ort.preload_dlls(directory="")
+            site_packages = sysconfig.get_paths()["purelib"]
+            nvidia_bin_dirs = glob.glob(
+                os.path.join(site_packages, "nvidia", "*", "bin")
+            )
+            if nvidia_bin_dirs:
+                os.environ["PATH"] = os.pathsep.join(nvidia_bin_dirs) + os.pathsep + os.environ.get("PATH", "")
+    except ImportError:
+        pass
+
 import asyncio
 import json
 import subprocess


### PR DESCRIPTION
## What does this PR do?
On Windows, required CUDA DLLs are available in the VENV but are not being loaded for AI tag prediction. This makes tag prediction fall back to CPU every time.

Fix: Add a call to onnxruntime.preload_dlls() and also add cuDNN bin to PATH at startup. This ensures all the necessary .dll files are available when needed.


## Checklist
- [ X ] I have read the [Contributing Guidelines](https://github.com/mrblomblo/blombooru/blob/main/CONTRIBUTING.md).
- [ X ] I have tested my changes and confirmed that Blombooru starts up and works as expected.
- [ X ] My PR addresses one thing only (e.g., `Fixes #40` or `Adds #41`, not `Fixes #40 and adds #41`).
- [ X ] I have not broken any existing functionality (or I have explained why the change was necessary below).

## Screenshots
N/A


## Additional context
As per discussions on Discord about the new CUDA tag prediction testing.

