### PR TITLE
Fix - Disabled default browser autocomplete from the search bar

### DIFF
--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -120,7 +120,7 @@
                     <div class="flex-1 max-w-2xl hidden sm:block">
                         <form id="search-form" class="flex gap-2 items-center">
                             <div class="relative flex-1">
-                                <input type="text" id="search-input" name="q"
+                                <input type="text" id="search-input" name="q" autocomplete="off"
                                     placeholder="{{ t('nav.search_placeholder') }}"
                                     value="{{ request.query_params.get('q', '') }}"
                                     class="w-full bg px-3 py-1 border text text-xs focus:outline-none focus:border-primary hover:border-primary transition-colors">
@@ -270,7 +270,7 @@
                 <div class="mt-2 sm:hidden">
                     <form id="search-form-mobile" class="flex gap-2 items-center">
                         <div class="relative flex-1">
-                            <input type="text" id="search-input-mobile" name="q"
+                            <input type="text" id="search-input-mobile" name="q" autocomplete="off"
                                 placeholder="{{ t('nav.search_placeholder') }}"
                                 value="{{ request.query_params.get('q', '') }}"
                                 class="w-full bg px-3 py-2 border text text-xs focus:outline-none focus:border-primary hover:border-primary transition-colors">


### PR DESCRIPTION

## What does this PR do?
Small bugfix to disable the browser's default autocomplete from the search field. 

On Firefox, the browser's default autocomplete would overlap with and get in the way of the custom one. Verified that the Blombooru autocomplete still works.


## Checklist
> [!IMPORTANT]
> Go through and check these before submitting.

- [x] I have read the [Contributing Guidelines](https://github.com/mrblomblo/blombooru/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes and confirmed that Blombooru starts up and works as expected.
- [x] My PR addresses one thing only (e.g., `Fixes #40` or `Adds #41`, not `Fixes #40 and adds #41`).
- [x] I have not broken any existing functionality (or I have explained why the change was necessary below).

## Screenshots
<!-- If applicable, add screenshots here. Required for theme PRs and UI changes. For theme updates, include before/after screenshots. -->
Before:
<img width="411" height="214" alt="seq" src="https://github.com/user-attachments/assets/fff8f108-f63c-420e-a405-34f9f968115e" />


After:
<img width="399" height="202" alt="Screenshot_152" src="https://github.com/user-attachments/assets/145dc829-f253-4bdc-80f7-889b370ab01b" />


## Additional context
<!-- Any extra information that might be helpful for reviewing this PR. If your changes modify existing behavior, explain why. -->
This could be a problem elsewhere, but I haven't run into it yet. Probably simply a matter of how much the search bar gets used compared to something like a field in the admin panel.