### PR TITLE
Prevent duplicate tag imps in backend

### DIFF
--- a/backend/app/routes/tag_implications.py
+++ b/backend/app/routes/tag_implications.py
@@ -152,7 +152,6 @@ async def create_implication(
     )
 
     implications = db.execute(stmt).scalars().all()
-    print(data.target_tag_patterns)
     exists = any(
         set(imp.target_tag_patterns or ()) == data.target_tag_patterns
         for imp in implications

--- a/backend/app/routes/tag_implications.py
+++ b/backend/app/routes/tag_implications.py
@@ -2,8 +2,11 @@ import asyncio
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
-from sqlalchemy.orm import Session, joinedload
+from pydantic import BaseModel, model_validator
+from pydantic.types import conset, StringConstraints
+from sqlalchemy import cast, select, Text
+from sqlalchemy.orm import Session 
+from typing import Annotated, Self
 
 from ..auth import require_admin_mode
 from ..database import get_db
@@ -29,12 +32,21 @@ class TagImplicationResponse(BaseModel):
     class Config:
         from_attributes = True
 
-class TagImplicationCreate(BaseModel):
-    target_tags: List[str]
-    target_tag_patterns: Optional[List[str]] = []
-    implied_tags: List[str]
+# Ensure a lower-case string stripped from whitespace with a minimum length of 1
+Tag_Or_Pattern = Annotated[str, StringConstraints(strip_whitespace=True, to_lower=True, min_length=1)]
 
-def _resolve_tag_names(db: Session, tag_names: List[str]) -> List[Tag]:
+class TagImplicationCreate(BaseModel):
+    target_tags: set[Tag_Or_Pattern] = set()
+    target_tag_patterns: set[Tag_Or_Pattern] = set()
+    implied_tags: conset(Tag_Or_Pattern, min_length=1)
+
+    @model_validator(mode="after")
+    def validate_target_presence(self) -> Self:
+        if not self.target_tags and not self.target_tag_patterns:
+            raise ValueError("either 'target_tags' or 'target_tag_patterns' is required")
+        return self
+
+def _resolve_tag_names(db: Session, tag_names: set[str]) -> List[Tag]:
     """Look up Tag objects by name. Raises 400 if any tag is not found."""
     tags = []
     for name in tag_names:
@@ -96,22 +108,31 @@ async def create_implication(
     db: Session = Depends(get_db)
 ):
     """Create a new tag implication."""
-    patterns = _clean_patterns(data.target_tag_patterns)
 
-    if not data.target_tags and not patterns:
-        raise HTTPException(status_code=400, detail="At least one target tag or target pattern is required")
-    if not data.implied_tags:
-        raise HTTPException(status_code=400, detail="At least one implied tag is required")
-
-    target_tags = _resolve_tag_names(db, data.target_tags)
+    target_tags = _resolve_tag_names(db, data.target_tags) if data.target_tags else []
     implied_tags = _resolve_tag_names(db, data.implied_tags)
 
-    if not implied_tags:
-        raise HTTPException(status_code=400, detail="At least one implied tag is required")
+    # Check whether there already exist an implication with these specific parameters
+    stmt = select(TagImplication.id)
+
+    for tag in implied_tags:
+        stmt = stmt.where(TagImplication.implied_tags.any(Tag.id == tag.id))
+
+    if data.target_tags:
+        for tag in target_tags:
+            stmt = stmt.where(TagImplication.target_tags.any(Tag.id == tag.id))
+
+    if data.target_tag_patterns:
+        for pattern in data.target_tag_patterns:
+            stmt = stmt.where(cast(TagImplication.target_tag_patterns, Text).contains(pattern))
+
+    exists = db.scalar(stmt)
+    if exists:
+        raise HTTPException(status_code=409, detail="Implication already exist")
 
     implication = TagImplication()
     implication.target_tags = target_tags
-    implication.target_tag_patterns = patterns if patterns else None
+    implication.target_tag_patterns = list(data.target_tag_patterns) if data.target_tag_patterns else None
     implication.implied_tags = implied_tags
 
     db.add(implication)

--- a/backend/app/routes/tag_implications.py
+++ b/backend/app/routes/tag_implications.py
@@ -4,13 +4,13 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, model_validator
 from pydantic.types import conset, StringConstraints
-from sqlalchemy import cast, select, Text
-from sqlalchemy.orm import Session 
+from sqlalchemy import cast, func, select, Text
+from sqlalchemy.orm import joinedload, Session
 from typing import Annotated, Self
 
 from ..auth import require_admin_mode
 from ..database import get_db
-from ..models import Media, Tag, TagImplication, User
+from ..models import blombooru_implication_implied, blombooru_implication_targets, Media, Tag, TagImplication, User 
 from ..utils.cache import invalidate_tag_cache
 from ..utils.tag_utils import expand_implications
 
@@ -112,21 +112,52 @@ async def create_implication(
     target_tags = _resolve_tag_names(db, data.target_tags) if data.target_tags else []
     implied_tags = _resolve_tag_names(db, data.implied_tags)
 
-    # Check whether there already exist an implication with these specific parameters
-    stmt = select(TagImplication.id)
+    target_ids = [tag.id for tag in target_tags]
+    implied_ids = [tag.id for tag in implied_tags]
 
-    for tag in implied_tags:
-        stmt = stmt.where(TagImplication.implied_tags.any(Tag.id == tag.id))
+    def matching_count_sq(table, tag_set):
+        """Generate a subquery selecting the count of matching tags (target or implied) for each implication"""
+        return (
+            select(func.count(table.c.tag_id))
+            .where(
+                table.c.implication_id == TagImplication.id,
+                table.c.tag_id.in_([tag.id for tag in tag_set])
+            )
+            .scalar_subquery()
+        )
 
-    if data.target_tags:
-        for tag in target_tags:
-            stmt = stmt.where(TagImplication.target_tags.any(Tag.id == tag.id))
+    def total_count_sq(table):
+        """Generate a subquery selecting the total count of tags (target or implied) for each implication"""
+        return (
+            select(func.count(table.c.tag_id))
+            .where(
+                table.c.implication_id == TagImplication.id
+            )
+            .scalar_subquery()
+        )
 
-    if data.target_tag_patterns:
-        for pattern in data.target_tag_patterns:
-            stmt = stmt.where(cast(TagImplication.target_tag_patterns, Text).contains(pattern))
+    matching_implied_count = matching_count_sq(blombooru_implication_implied, implied_tags)
+    total_implied_count = total_count_sq(blombooru_implication_implied)
+    matching_target_count = matching_count_sq(blombooru_implication_targets, target_tags)
+    total_target_count = total_count_sq(blombooru_implication_targets)
 
-    exists = db.scalar(stmt)
+    stmt = (
+        select(TagImplication)
+        .where(
+            matching_implied_count == len(implied_tags), # it must contain at least the implied tags
+            total_implied_count == len(implied_tags),  # but it must not contain any more then those
+            matching_target_count == len(target_tags),
+            total_target_count == len(target_tags),
+        )
+    )
+
+    implications = db.execute(stmt).scalars().all()
+    print(data.target_tag_patterns)
+    exists = any(
+        set(imp.target_tag_patterns or ()) == data.target_tag_patterns
+        for imp in implications
+    )
+
     if exists:
         raise HTTPException(status_code=409, detail="Implication already exist")
 

--- a/tests/test_tag_implications.py
+++ b/tests/test_tag_implications.py
@@ -1,6 +1,7 @@
 import asyncio
 import unittest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from backend.app.enums import FileTypeEnum, RatingEnum, TagCategoryEnum
 from backend.app.models import Media, Tag, TagImplication, User
@@ -151,31 +152,23 @@ class TestTagImplications(BackupTestBase):
         self.assertEqual(res.target_tag_patterns, ["*girl*"])
         self.assertEqual({t.name for t in res.implied_tags}, {"1girl"})
 
-    def test_create_implication_validation_errors(self):
+    def test_implication_validation_errors(self):
         """Test validation error cases when target tags or implied tags are missing."""
-        # Neither target tags nor patterns provided
-        data_no_targets = TagImplicationCreate(
-            target_tags=[],
-            target_tag_patterns=[],
-            implied_tags=["animal"]
-        )
-        with self.assertRaises((HTTPException, ValueError)) as ctx:
-            asyncio.run(create_implication(data_no_targets, current_user=self.admin_user, db=self.db))
-        if isinstance(ctx.exception, HTTPException):
-            self.assertEqual(ctx.exception.status_code, 400)
-
+        # Validation thrown error when either target_tags or target_tag_parrents are provided
+        with self.assertRaises(ValidationError) as ctx:
+            data_no_targets = TagImplicationCreate(
+                target_tags=[],
+                target_tag_patterns=[],
+                implied_tags=["animal"]
+            )
+    
         # No implied tags provided
-        try:
+        with self.assertRaises(ValidationError) as ctx:
             data_no_implied = TagImplicationCreate(
                 target_tags=["cat"],
                 target_tag_patterns=[],
                 implied_tags=[]
             )
-            with self.assertRaises(HTTPException) as ctx:
-                asyncio.run(create_implication(data_no_implied, current_user=self.admin_user, db=self.db))
-            self.assertEqual(ctx.exception.status_code, 400)
-        except ValueError:
-            pass
 
     def test_list_implications(self):
         """Test listing all implications returns formatted records and normalizes patterns to list."""


### PR DESCRIPTION
## What does this PR do?
Prevents duplicate tag implications from being created in the backend, more specifically on the `/api/tag-implications/` route.
I also took the liberty of moving most of the data validation on that particular endpoint to the corresponding pydantic model. Main motivation was to ensure that when the route is hit, the data is valid.

Fixes #126 

## Checklist
> [!IMPORTANT]
> Go through and check these before submitting.

- [x] I have read the [Contributing Guidelines](https://github.com/mrblomblo/blombooru/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes and confirmed that Blombooru starts up and works as expected.
- [x] My PR addresses one thing only (e.g., `Fixes #40` or `Adds #41`, not `Fixes #40 and adds #41`).
- [x] I have not broken any existing functionality (or I have explained why the change was necessary below).

## Additional context
I'm not super comfortable with sql so am not sure whether the existence query is completely bonkers or not 😅 

